### PR TITLE
No need to check for click on desktop window on release

### DIFF
--- a/src/desktopclick/dclick.c
+++ b/src/desktopclick/dclick.c
@@ -18,6 +18,7 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
+ * TODO: cleanup indentation
  */
 
 #include <compiz-core.h>
@@ -189,11 +190,6 @@ dclickHandleDesktopButtonPress (CompDisplay    *d,
 	{
 
 	DCLICK_DISPLAY (d);
-
-	CompWindow *w = findWindowAtDisplay (d, win); 
-	if ((!w || (w->type & CompWindowTypeDesktopMask) == 0) && 
-	(win != s->root)) 
-	return FALSE; 	/* Oops, we didn't hit the desktop window */
 
 	CompListValue *cModsEnum = dclickGetClickMods (d);
 	CompListValue *cButtonEnum = dclickGetClickButtons (d);


### PR DESCRIPTION
since the cursor may have moved and the user probably wants to terminate the "current" action. The previous behaviour also made no sense for plugins which grab the screen on initiate